### PR TITLE
Improve 'blockchain verify'

### DIFF
--- a/src/blockchain/commands.rs
+++ b/src/blockchain/commands.rs
@@ -449,6 +449,12 @@ pub fn verify_chain( mut term: Term
 {
     let blockchain = Blockchain::load(root_dir, name);
 
+    let tip = blockchain.load_tip().0;
+    let num_blocks = tip.date.slot_number();
+
+    let progress = term.progress_bar(num_blocks as u64);
+    progress.set_message("verifying blocks... ");
+
     let mut bad_blocks = 0;
     let mut nr_blocks = 0;
     let mut chain_state = cardano::block::ChainState::new(&blockchain.config.genesis_prev);
@@ -459,17 +465,18 @@ pub fn verify_chain( mut term: Term
         let rblk = rblk.unwrap();
         let blk = rblk.decode().unwrap();
         let hash = blk.get_header().compute_hash();
-        //writeln!(term, "block {} {}", hash, blk.get_header().get_blockdate()).unwrap();
         match cardano::block::verify_block_in_chain(blockchain.config.protocol_magic, &mut chain_state, &hash, &blk) {
             Ok(()) => {},
             Err(err) => {
                 bad_blocks += 1;
                 term.error(&format!("Block {} ({}) is invalid: {:?}", hash, blk.get_header().get_blockdate(), err)).unwrap();
                 term.simply("\n").unwrap();
-                //::std::process::exit(1);
             }
         }
+        progress.inc(1);
     }
+
+    progress.finish();
 
     if bad_blocks > 0 {
         term.error(&format!("{} out of {} blocks are invalid", bad_blocks, nr_blocks)).unwrap();

--- a/src/blockchain/commands.rs
+++ b/src/blockchain/commands.rs
@@ -457,13 +457,15 @@ pub fn verify_chain( mut term: Term
 
     let mut bad_blocks = 0;
     let mut nr_blocks = 0;
-    let mut chain_state = cardano::block::ChainState::new(&blockchain.config.genesis_prev);
+    let mut chain_state = cardano::block::ChainState::new(
+        &blockchain.config.genesis_prev,
+        blockchain.config.protocol_magic);
 
     for res in blockchain.iter_to_tip(blockchain.config.genesis.clone()).unwrap() {
         let (rblk, blk) = res.unwrap();
         nr_blocks += 1;
         let hash = blk.get_header().compute_hash();
-        match cardano::block::verify_block_in_chain(blockchain.config.protocol_magic, &mut chain_state, &hash, &blk) {
+        match chain_state.verify_block(&hash, &blk) {
             Ok(()) => {},
             Err(err) => {
                 bad_blocks += 1;

--- a/src/blockchain/commands.rs
+++ b/src/blockchain/commands.rs
@@ -459,11 +459,9 @@ pub fn verify_chain( mut term: Term
     let mut nr_blocks = 0;
     let mut chain_state = cardano::block::ChainState::new(&blockchain.config.genesis_prev);
 
-    for rblk in blockchain.iter_to_tip(blockchain.config.genesis.clone()).unwrap() {
+    for res in blockchain.iter_to_tip(blockchain.config.genesis.clone()).unwrap() {
+        let (rblk, blk) = res.unwrap();
         nr_blocks += 1;
-        // FIXME: inefficient - the iterator has already decoded the block.
-        let rblk = rblk.unwrap();
-        let blk = rblk.decode().unwrap();
         let hash = blk.get_header().compute_hash();
         match cardano::block::verify_block_in_chain(blockchain.config.protocol_magic, &mut chain_state, &hash, &blk) {
             Ok(()) => {},

--- a/src/blockchain/commands.rs
+++ b/src/blockchain/commands.rs
@@ -451,6 +451,7 @@ pub fn verify_chain( mut term: Term
 
     let mut bad_blocks = 0;
     let mut nr_blocks = 0;
+    let mut chain_state = cardano::block::ChainState::new(&blockchain.config.genesis_prev);
 
     for rblk in blockchain.iter_to_tip(blockchain.config.genesis.clone()).unwrap() {
         nr_blocks += 1;
@@ -458,8 +459,8 @@ pub fn verify_chain( mut term: Term
         let rblk = rblk.unwrap();
         let blk = rblk.decode().unwrap();
         let hash = blk.get_header().compute_hash();
-        writeln!(term, "block {} {}", hash, blk.get_header().get_blockdate()).unwrap();
-        match cardano::block::verify_block(blockchain.config.protocol_magic, &hash, &blk) {
+        //writeln!(term, "block {} {}", hash, blk.get_header().get_blockdate()).unwrap();
+        match cardano::block::verify_block_in_chain(blockchain.config.protocol_magic, &mut chain_state, &hash, &blk) {
             Ok(()) => {},
             Err(err) => {
                 bad_blocks += 1;

--- a/src/wallet/state/iter.rs
+++ b/src/wallet/state/iter.rs
@@ -34,9 +34,9 @@ impl<'a> TransactionIterator<'a> {
     fn skip_no_transactions(&mut self) -> blockchain::iter::Result<()> {
         self.current_tx = None;
         loop {
-            if let Some(raw_block) = self.block_iterator.next() {
+            if let Some(res) = self.block_iterator.next() {
                 self.progress.inc(1);
-                let block = raw_block?.decode()?;
+                let (_, block) = res?;
                 if block.has_transactions() {
                     self.current_tx = Some((block, 0));
                     break;


### PR DESCRIPTION
It now calls `verify_block_in_chain` to verify blocks in the context of the chain, adds a progress bar, and gets rid of the duplicate decoding of blocks in the iterator.