### PR TITLE
Upgrade cardano-deps to latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ name = "cardano"
 version = "0.1.0"
 dependencies = [
  "cbor_event 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cryptoxide 0.1.0",
+ "cryptoxide 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -100,7 +100,6 @@ version = "0.1.0"
 dependencies = [
  "cardano 0.1.0",
  "cbor_event 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cryptoxide 0.1.0",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage-units 0.1.0",
@@ -195,10 +194,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "cryptoxide"
 version = "0.1.0"
-
-[[package]]
-name = "cryptoxide"
-version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -243,7 +238,6 @@ dependencies = [
  "cardano 0.1.0",
  "cardano-storage 0.1.0",
  "cbor_event 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cryptoxide 0.1.0",
  "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.11.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -760,7 +754,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "storage-units"
 version = "0.1.0"
 dependencies = [
- "cryptoxide 0.1.0",
+ "cryptoxide 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,7 @@ dependencies = [
 name = "cardano"
 version = "0.1.0"
 dependencies = [
- "cbor_event 0.1.0",
+ "cbor_event 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cryptoxide 0.1.0",
  "serde 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -75,10 +75,11 @@ name = "cardano-cli"
 version = "0.0.1"
 dependencies = [
  "cardano 0.1.0",
- "cbor_event 0.1.0",
+ "cardano-storage 0.1.0",
+ "cbor_event 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "console 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cryptoxide 0.1.0",
+ "cryptoxide 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dialoguer 0.1.0 (git+https://github.com/primetype/dialoguer?rev=bcd067b454bfc03b2a3dc5d4be314c9852265fac)",
  "dirs 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -90,12 +91,25 @@ dependencies = [
  "serde 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "storage 0.1.0",
+ "storage-units 0.1.0",
+]
+
+[[package]]
+name = "cardano-storage"
+version = "0.1.0"
+dependencies = [
+ "cardano 0.1.0",
+ "cbor_event 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cryptoxide 0.1.0",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "storage-units 0.1.0",
 ]
 
 [[package]]
 name = "cbor_event"
-version = "0.1.0"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cfg-if"
@@ -183,6 +197,11 @@ name = "cryptoxide"
 version = "0.1.0"
 
 [[package]]
+name = "cryptoxide"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "dialoguer"
 version = "0.1.0"
 source = "git+https://github.com/primetype/dialoguer?rev=bcd067b454bfc03b2a3dc5d4be314c9852265fac#bcd067b454bfc03b2a3dc5d4be314c9852265fac"
@@ -222,7 +241,8 @@ name = "exe-common"
 version = "0.1.0"
 dependencies = [
  "cardano 0.1.0",
- "cbor_event 0.1.0",
+ "cardano-storage 0.1.0",
+ "cbor_event 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cryptoxide 0.1.0",
  "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.11.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -232,7 +252,7 @@ dependencies = [
  "serde 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.78 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "storage 0.1.0",
+ "storage-units 0.1.0",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -520,7 +540,7 @@ name = "protocol"
 version = "0.1.0"
 dependencies = [
  "cardano 0.1.0",
- "cbor_event 0.1.0",
+ "cbor_event 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -737,13 +757,10 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "storage"
+name = "storage-units"
 version = "0.1.0"
 dependencies = [
- "cardano 0.1.0",
- "cbor_event 0.1.0",
  "cryptoxide 0.1.0",
- "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1170,6 +1187,7 @@ dependencies = [
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "90492c5858dd7d2e78691cfb89f90d273a2800fc11d98f60786e5d87e2f83781"
 "checksum bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0ce55bd354b095246fc34caf4e9e242f5297a7fd938b090cadfea6eee614aa62"
+"checksum cbor_event 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29a95a1de12d1f5a3ff0c34cd2578f625a5feddb5d5672546ebbbecdb6287a0f"
 "checksum cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4e7bb64a8ebb0d856483e1e682ea3422f883c5f5615a90d51a2c82fe87fdd3"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum clicolors-control 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1f84dec9bc083ce2503908cd305af98bd363da6f54bf8d4bf0ac14ee749ad5d1"
@@ -1178,6 +1196,7 @@ dependencies = [
 "checksum crossbeam-deque 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3486aefc4c0487b9cb52372c97df0a48b8c249514af1ee99703bf70d2f2ceda1"
 "checksum crossbeam-epoch 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "30fecfcac6abfef8771151f8be4abc9e4edc112c2bcb233314cafde2680536e9"
 "checksum crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "677d453a17e8bd2b913fa38e8b9cf04bcdbb5be790aa294f2389661d72036015"
+"checksum cryptoxide 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc9be687df90da186ed5c6ada0b6b4d69f5ad914071870bc5d41277377d30427"
 "checksum dialoguer 0.1.0 (git+https://github.com/primetype/dialoguer?rev=bcd067b454bfc03b2a3dc5d4be314c9852265fac)" = "<none>"
 "checksum dirs 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f679c09c1cf5428702cc10f6846c56e4e23420d3a88bcc9335b17c630a7b710b"
 "checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,10 +29,11 @@ serde_derive = "1.0"
 serde_yaml = "0.8"
 env_logger = "0.5"
 humantime = "1.1"
-cbor_event = { path = "cardano-deps/cbor_event" }
-cryptoxide = { path = "cardano-deps/cryptoxide" }
-exe-common = { path = "cardano-deps/exe-common" }
-storage    = { path = "cardano-deps/storage" }
+cbor_event = "1.0"
+cryptoxide = "0.1"
+exe-common      = { path = "cardano-deps/exe-common" }
+cardano-storage = { path = "cardano-deps/storage" }
+storage-units   = { path = "cardano-deps/storage-units" }
 
 [dependencies.clap]
 version = "2.32"

--- a/src/blockchain/commands.rs
+++ b/src/blockchain/commands.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::io::{Write};
 
 use exe_common::config::net::Config;
-use storage;
+use cardano_storage as storage;
 
 use utils::term::Term;
 
@@ -257,7 +257,7 @@ pub fn forward( mut term: Term
     let hash = if let Some(hash_hex) = to {
         let hash = super::config::parse_block_hash(&mut term, &hash_hex);
 
-        if ::storage::block_location(&blockchain.storage, &hash).is_none() {
+        if storage::block_location(&blockchain.storage, &hash).is_none() {
             term.error(&format!("block hash `{}' is not present in the local blockchain\n", hash_hex)).unwrap();
             ::std::process::exit(1);
         }
@@ -306,7 +306,7 @@ pub fn pull( mut term: Term
 fn get_block(mut term: &mut Term, blockchain: &Blockchain, hash_str: &str) -> RawBlock
 {
     let hash = super::config::parse_block_hash(&mut term, &hash_str);
-    let block_location = match ::storage::block_location(&blockchain.storage, &hash) {
+    let block_location = match storage::block_location(&blockchain.storage, &hash) {
         None => {
             term.error(&format!("block hash `{}' is not present in the local blockchain\n", hash_str)).unwrap();
             ::std::process::exit(1);
@@ -316,7 +316,7 @@ fn get_block(mut term: &mut Term, blockchain: &Blockchain, hash_str: &str) -> Ra
 
     debug!("blk location: {:?}", block_location);
 
-    match ::storage::block_read_location(&blockchain.storage, &block_location, &hash) {
+    match storage::block_read_location(&blockchain.storage, &block_location, &hash) {
         None        => {
             // this is a bug, we have a block location available for this hash
             // but we were not able to read the block.

--- a/src/blockchain/iter/epoch.rs
+++ b/src/blockchain/iter/epoch.rs
@@ -4,7 +4,8 @@
 //!
 
 use cardano::block::{EpochId, RawBlock};
-use storage::{StorageConfig, epoch::{epoch_read_pack, epoch_open_pack_reader}, pack::packreader_init, containers::packfile};
+use cardano_storage::{StorageConfig, epoch::{epoch_read_pack, epoch_open_pack_reader}, pack::packreader_init};
+use storage_units::packfile;
 
 use std::{fs};
 

--- a/src/blockchain/iter/error.rs
+++ b/src/blockchain/iter/error.rs
@@ -2,7 +2,7 @@
 pub enum Error {
     IoError(::std::io::Error),
     CborError(::cbor_event::Error),
-    StorageError(::storage::Error),
+    StorageError(::cardano_storage::Error),
 }
 impl From<::std::io::Error> for Error {
     fn from(e: ::std::io::Error) -> Self { Error::IoError(e) }
@@ -10,8 +10,8 @@ impl From<::std::io::Error> for Error {
 impl From<::cbor_event::Error> for Error {
     fn from(e: ::cbor_event::Error) -> Self { Error::CborError(e) }
 }
-impl From<::storage::Error> for Error {
-    fn from(e: ::storage::Error) -> Self { Error::StorageError(e) }
+impl From<::cardano_storage::Error> for Error {
+    fn from(e: ::cardano_storage::Error) -> Self { Error::StorageError(e) }
 }
 
 pub type Result<T> = ::std::result::Result<T, Error>;

--- a/src/blockchain/iter/mod.rs
+++ b/src/blockchain/iter/mod.rs
@@ -4,7 +4,7 @@ pub mod epoch;
 pub use self::error::{Error, Result};
 
 use cardano::block::{RawBlock, HeaderHash};
-use storage::{self, Storage};
+use cardano_storage::{self as storage, Storage};
 
 enum IteratorType<'a> {
     Epoch(epoch::Epochs<'a>, Option<epoch::Iter>),

--- a/src/blockchain/mod.rs
+++ b/src/blockchain/mod.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 
 use exe_common::network::api::BlockRef;
 pub use exe_common::{config::net::{self, Config, Peer, Peers}, network};
-use storage::{tag, Storage, config::{StorageConfig}};
+use cardano_storage::{self as storage, tag, Storage, config::{StorageConfig}};
 use cardano::block;
 
 pub const LOCAL_BLOCKCHAIN_TIP_TAG : &'static str = "tip";
@@ -119,7 +119,7 @@ impl Blockchain {
             date: block::BlockDate::Genesis(self.config.epoch_start)
         }, true);
         match self.storage.get_block_from_tag(LOCAL_BLOCKCHAIN_TIP_TAG) {
-            Err(::storage::Error::NoSuchTag) => genesis_ref,
+            Err(storage::Error::NoSuchTag) => genesis_ref,
             Err(err) => panic!(err),
             Ok(block) => {
                 let header = block.get_header();

--- a/src/blockchain/peer.rs
+++ b/src/blockchain/peer.rs
@@ -3,7 +3,8 @@ use exe_common;
 use exe_common::network::{api::Api, api::BlockRef};
 use cardano::{block::{BlockDate, EpochId, HeaderHash}, tx::{TxAux}};
 use utils::term::Term;
-use storage::{self, tag};
+use cardano_storage::{self as storage, tag};
+use storage_units::packfile;
 use std::ops::Deref;
 use std::time::SystemTime;
 use std::mem;
@@ -100,7 +101,7 @@ impl<'a> ConnectedPeer<'a> {
             };
         info!("First unstable epoch : {}", first_unstable_epoch);
 
-        let mut cur_epoch_state : Option<(EpochId, storage::containers::packfile::Writer, SystemTime)> = None;
+        let mut cur_epoch_state : Option<(EpochId, packfile::Writer, SystemTime)> = None;
 
         let mut last_block : Option<HeaderHash> = None;
 
@@ -299,7 +300,8 @@ impl<'a> Peer<'a> {
 }
 
 mod internal {
-    use storage::{self, block_read};
+    use cardano_storage::{self as storage, block_read};
+    use storage_units::packfile;
     use cardano::block::{EpochId, HeaderHash};
     use cardano::util::{hex};
     use std::time::{SystemTime, Duration};
@@ -338,7 +340,7 @@ mod internal {
     pub fn append_blocks_to_epoch_reverse(
         storage: &storage::Storage,
         epoch_id : EpochId,
-        writer : &mut storage::containers::packfile::Writer,
+        writer : &mut packfile::Writer,
         last_block: &HeaderHash)
         -> HeaderHash
     {
@@ -361,7 +363,7 @@ mod internal {
         cur_hash
     }
 
-    pub fn finish_epoch(storage: &storage::Storage, epoch_id : EpochId, writer : storage::containers::packfile::Writer, epoch_time_start : &SystemTime)
+    pub fn finish_epoch(storage: &storage::Storage, epoch_id : EpochId, writer : packfile::Writer, epoch_time_start : &SystemTime)
     {
         let (packhash, index) = storage::pack::packwriter_finalize(&storage.config, writer);
         let (_, tmpfile) = storage::pack::create_index(&storage, &index);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,8 @@ extern crate cryptoxide;
 extern crate cbor_event;
 extern crate cardano;
 extern crate exe_common;
-extern crate storage;
+extern crate cardano_storage;
+extern crate storage_units;
 
 extern crate console;
 extern crate dialoguer;

--- a/src/transaction/core/staging_id.rs
+++ b/src/transaction/core/staging_id.rs
@@ -1,5 +1,5 @@
 use rand;
-use storage::utils::serialize::{SIZE_SIZE, read_size, write_size};
+use storage_units::utils::serialize::{SIZE_SIZE, read_size, write_size};
 use cardano::util::{base58};
 use std::{str, fmt};
 use serde::{ser, de};

--- a/src/transaction/core/staging_transaction.rs
+++ b/src/transaction/core/staging_transaction.rs
@@ -1,4 +1,4 @@
-use storage::{containers::append, utils::{serialize, lock::{self, Lock}}};
+use storage_units::{append, utils::{serialize, lock::{self, Lock}}};
 use cardano::{util::{hex}, address::{ExtendedAddr}, tx::{TxInWitness, TxIn, TxAux}, config::{ProtocolMagic}};
 use std::{path::PathBuf};
 

--- a/src/wallet/commands.rs
+++ b/src/wallet/commands.rs
@@ -370,7 +370,7 @@ pub fn address( mut term: Term
         },
         HDWalletModel::RandomIndex2Levels => {
             let lookup_struct = load_randomindex_lookup_structure(&mut term, &wallet);
-            let addressing = ::cardano::wallet::rindex::Addressing(account, index);
+            let addressing = ::cardano::wallet::rindex::Addressing::new(account, index);
             lookup_struct.get_address(&addressing)
         }
     };

--- a/src/wallet/error.rs
+++ b/src/wallet/error.rs
@@ -1,5 +1,5 @@
 use cardano::hdwallet;
-use storage::utils::lock;
+use storage_units::utils::lock;
 
 use super::state::log;
 

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -15,7 +15,7 @@ use self::state::log::{LogLock, LogWriter};
 
 use std::{fmt, path::PathBuf, fs, io::{Read, Write}, collections::{BTreeMap}};
 use cardano::{wallet, hdwallet::{XPub, XPUB_SIZE}};
-use storage::utils::{tmpfile::{TmpFile}};
+use storage_units::utils::{tmpfile::{TmpFile}};
 use serde_yaml;
 
 use utils::password_encrypted::{Password};

--- a/src/wallet/state/log.rs
+++ b/src/wallet/state/log.rs
@@ -1,4 +1,4 @@
-use storage::{containers::append, utils::{serialize, lock::{self, Lock}}};
+use storage_units::{append, utils::{serialize, lock::{self, Lock}}};
 use std::{path::{PathBuf}, fmt, result, io::{self, Read, Write}};
 use cardano::{block::{BlockDate, HeaderHash, types::EpochSlotId}};
 


### PR DESCRIPTION
include some bug fixes, more thoroughly tested interfaces, uses crates deployed on rust crates.io and fix the bug of usage of non hardened keys in daedalus style derivation