### PR TITLE
JSON output from cat command

### DIFF
--- a/src/blockchain/commands.rs
+++ b/src/blockchain/commands.rs
@@ -249,7 +249,7 @@ pub fn log( term: &mut Term
         use utils::pretty::Pretty;
 
         writeln!(term, "[");
-        block.pretty(term, 0)?;
+        block.pretty(term, 2*::utils::pretty::DISPLAY_INDENT_SIZE)?;
         writeln!(term, "]");
     }
 
@@ -357,9 +357,9 @@ pub fn cat( term: &mut Term
         if debug {
             writeln!(term, "{:#?}", blk)?;
         } else {
-            writeln!(term, "[");
-            blk.pretty(term, 0)?;
-            writeln!(term, "]");
+            write!(term, "[");
+            blk.pretty(term, 2*::utils::pretty::DISPLAY_INDENT_SIZE)?;
+            writeln!(term, "\n]");
         }
     }
 

--- a/src/blockchain/commands.rs
+++ b/src/blockchain/commands.rs
@@ -248,7 +248,9 @@ pub fn log( term: &mut Term
     for block in storage::block::iter::ReverseIter::from(&blockchain.storage, from).unwrap() {
         use utils::pretty::Pretty;
 
+        writeln!(term, "[");
         block.pretty(term, 0)?;
+        writeln!(term, "]");
     }
 
     Ok(())
@@ -355,7 +357,9 @@ pub fn cat( term: &mut Term
         if debug {
             writeln!(term, "{:#?}", blk)?;
         } else {
+            writeln!(term, "[");
             blk.pretty(term, 0)?;
+            writeln!(term, "]");
         }
     }
 

--- a/src/utils/pretty.rs
+++ b/src/utils/pretty.rs
@@ -14,15 +14,18 @@ pub trait Pretty {
 }
 
 fn pretty_attribute<P: Pretty, W: Write>(w: &mut W, indent: usize, k: &'static str, v: P) -> Result<()> {
-    write!(w, "{:width$}{}: ", "", k, width = indent)?;
+    write!(w, "{:width$}\"{}\": ", "", k, width = indent)?;
     v.pretty(w, indent + DISPLAY_INDENT_SIZE)?;
     writeln!(w, "")?;
     Ok(())
 }
-fn pretty_object<P: Pretty, W: Write>(w: &mut W, indent: usize, k: &'static str, v: P) -> Result<()> {
-    writeln!(w, "{:width$}{}:", "", k, width = indent)?;
-    v.pretty(w, indent + DISPLAY_INDENT_SIZE)?;
-    writeln!(w, "")?;
+
+fn pretty_obj_start<W: Write>(w: &mut W, indent: usize) -> Result<()> {
+    writeln!(w, "\n{:width$}{}{{", "", "", width = indent)?;
+    Ok(())
+}
+fn pretty_obj_end<W: Write>(w: &mut W, indent: usize) -> Result<()> {
+    writeln!(w, "{:width$}{}}},", "", "", width = indent)?;
     Ok(())
 }
 
@@ -30,7 +33,7 @@ impl<'a> Pretty for &'a str {
     fn pretty<W>(self, f: &mut W, _: usize) -> Result<()>
         where W: Write
     {
-        write!(f, "{}", self)
+        write!(f, "\"{}\",", self)
     }
 }
 
@@ -38,7 +41,7 @@ impl<D: ::std::fmt::Display> Pretty for StyledObject<D> {
     fn pretty<W>(self, f: &mut W, _: usize) -> Result<()>
         where W: Write
     {
-        write!(f, "{}", self)
+        write!(f, "\"{}\",", self)
     }
 }
 
@@ -46,7 +49,7 @@ impl<'a, D: ::std::fmt::Display> Pretty for &'a StyledObject<D> {
     fn pretty<W>(self, f: &mut W, _: usize) -> Result<()>
         where W: Write
     {
-        write!(f, "{}", self)
+        write!(f, "\"{}\",", self)
     }
 }
 
@@ -55,11 +58,12 @@ fn pretty_iterator<I, D, W>(w: &mut W, indent: usize, iter: I) -> Result<()>
         , D: Pretty
         , W: Write
 {
+    write!(w, "\n{:width$}[", "", width = indent)?;
     for e in iter {
         write!(w, "{:width$}", "", width = indent)?;
         e.pretty(w, indent + DISPLAY_INDENT_SIZE)?;
-        writeln!(w, "")?;
     }
+    write!(w, "{:width$}],", "", width = indent)?;
     Ok(())
 }
 
@@ -75,19 +79,29 @@ impl Pretty for Block {
     fn pretty<W>(self, f: &mut W, indent: usize) -> Result<()>
         where W: Write
     {
+        pretty_obj_start(f, indent)?;
         match self {
-            Block::GenesisBlock(blk) => blk.pretty(f, indent),
-            Block::MainBlock(blk) => blk.pretty(f, indent),
+            Block::GenesisBlock(blk) => 
+            {
+                pretty_attribute(f, indent, "gen_block", blk)?;
+            }
+            Block::MainBlock(blk) => {
+                pretty_attribute(f, indent, "block", blk)?;
+            }
         }
+        pretty_obj_end(f, indent)?;
+        Ok(())
     }
 }
 impl Pretty for genesis::Block {
     fn pretty<W>(self, f: &mut W, indent: usize) -> Result<()>
         where W: Write
     {
-        pretty_object(f, indent, "header", self.header)?;
-        pretty_object(f, indent, "body", self.body)?;
+        pretty_obj_start(f, indent)?;
+        pretty_attribute(f, indent, "header", self.header)?;
+        pretty_attribute(f, indent, "body", self.body)?;
         // TODO: extra?
+        pretty_obj_end(f, indent)?;
         Ok(())
     }
 }
@@ -95,9 +109,11 @@ impl Pretty for normal::Block {
     fn pretty<W>(self, f: &mut W, indent: usize) -> Result<()>
         where W: Write
     {
-        pretty_object(f, indent, "header", self.header)?;
-        pretty_object(f, indent, "body", self.body)?;
+        pretty_obj_start(f, indent)?;
+        pretty_attribute(f, indent, "header", self.header)?;
+        pretty_attribute(f, indent, "body", self.body)?;
         // TODO: extra?
+        pretty_obj_end(f, indent)?;
         Ok(())
     }
 }
@@ -105,10 +121,12 @@ impl Pretty for genesis::Body {
     fn pretty<W>(self, f: &mut W, indent: usize) -> Result<()>
         where W: Write
     {
+        pretty_obj_start(f, indent)?;
         // pretty_attribute(f, indent, "ssc", self.ssc)?;
-        pretty_object(f, indent, "slot_leaders", self.slot_leaders)?;
+        pretty_attribute(f, indent, "slot_leaders", self.slot_leaders)?;
         // TODO: delegation?
         // TODO: update?
+        pretty_obj_end(f, indent)?;
         Ok(())
     }
 }
@@ -116,10 +134,12 @@ impl Pretty for normal::Body {
     fn pretty<W>(self, f: &mut W, indent: usize) -> Result<()>
         where W: Write
     {
+        pretty_obj_start(f, indent)?;
         // pretty_attribute(f, indent, "ssc", self.ssc)?;
-        self.tx.pretty(f, indent)?;
+        pretty_attribute(f, indent, "txs", self.tx)?;
         // TODO: delegation?
         // TODO: update?
+        pretty_obj_end(f, indent)?;
         Ok(())
     }
 }
@@ -134,8 +154,10 @@ impl Pretty for tx::TxAux {
     fn pretty<W>(self, f: &mut W, indent: usize) -> Result<()>
         where W: Write
     {
-        pretty_object(f, indent, "tx", self.tx)?;
-        pretty_object(f, indent, "witnesses", self.witness.to_vec())?;
+        pretty_obj_start(f, indent)?;
+        pretty_attribute(f, indent, "tx", self.tx)?;
+        pretty_attribute(f, indent, "witnesses", self.witness.to_vec())?;
+        pretty_obj_end(f, indent)?;
         Ok(())
     }
 }
@@ -143,47 +165,62 @@ impl Pretty for tx::Tx {
     fn pretty<W>(self, f: &mut W, indent: usize) -> Result<()>
         where W: Write
     {
-        pretty_object(f, indent, "inputs", self.inputs)?;
-        pretty_object(f, indent, "outputs", self.outputs)?;
+        pretty_obj_start(f, indent)?;
+        pretty_attribute(f, indent, "inputs", self.inputs)?;
+        pretty_attribute(f, indent, "outputs", self.outputs)?;
+        pretty_obj_end(f, indent)?;
         Ok(())
     }
 }
 impl Pretty for tx::TxoPointer {
-    fn pretty<W>(self, f: &mut W, _: usize) -> Result<()>
+    fn pretty<W>(self, f: &mut W, indent: usize) -> Result<()>
         where W: Write
     {
-        write!(f, "{}@{}", style!(self.id), style!(self.index).yellow())
+        pretty_obj_start(f, indent)?;
+        pretty_attribute(f, indent, "id", style!(self.id))?;
+        pretty_attribute(f, indent, "index", style!(self.index))?;
+        pretty_obj_end(f, indent)?;
+        Ok(())
     }
 }
 impl Pretty for tx::TxOut {
-    fn pretty<W>(self, f: &mut W, _: usize) -> Result<()>
+    fn pretty<W>(self, f: &mut W, indent: usize) -> Result<()>
         where W: Write
     {
-        write!(f, "{} {}", style!(self.address), style!(self.value))
+        pretty_obj_start(f, indent)?;
+        pretty_attribute(f, indent, "address", style!(self.address))?;
+        pretty_attribute(f, indent, "value", style!(self.value))?;
+        pretty_obj_end(f, indent)?;
+        Ok(())
     }
 }
 impl Pretty for tx::TxInWitness {
-    fn pretty<W>(self, f: &mut W, _: usize) -> Result<()>
+    fn pretty<W>(self, f: &mut W, indent: usize) -> Result<()>
         where W: Write
     {
+        pretty_obj_start(f, indent)?;
         match self {
             tx::TxInWitness::PkWitness(xpub, signature) => {
-                write!(f, "{} {} ({})", style!(xpub), style!(signature), style!("Public Key"))
+                pretty_attribute(f, indent, "xpub", style!(xpub))?;
+                pretty_attribute(f, indent, "signature", style!(signature))?;
+                pretty_attribute(f, indent, "type", style!("Public Key"))?;
             },
             tx::TxInWitness::ScriptWitness(_, _) => {
-                write!(f, "({})", style!("Script"))
+                pretty_attribute(f, indent, "type", style!("Script"))?;
             },
             tx::TxInWitness::RedeemWitness(public, signature) => {
-                write!(f, "{} {} ({})", style!(public), style!(signature), style!("Redeem"))
+                pretty_attribute(f, indent, "type", style!("Redeem"))?;
             },
         }
+        pretty_obj_end(f, indent)?;
+        Ok(())
     }
 }
 impl Pretty for address::StakeholderId {
     fn pretty<W>(self, f: &mut W, _: usize) -> Result<()>
         where W: Write
     {
-        write!(f, "{}", style!(self))
+        write!(f, "\"{}\",", style!(self))
     }
 }
 
@@ -191,11 +228,13 @@ impl Pretty for genesis::BlockHeader {
     fn pretty<W>(self, f: &mut W, indent: usize) -> Result<()>
         where W: Write
     {
+        pretty_obj_start(f, indent)?;
         pretty_attribute(f, indent, "protocol_magic", style!(self.protocol_magic))?;
         pretty_attribute(f, indent, "previous_header", style!(self.previous_header))?;
         pretty_attribute(f, indent, "body_proof", style!(self.body_proof))?;
-        pretty_object(f, indent, "consensus", self.consensus)?;
+        pretty_attribute(f, indent, "consensus", self.consensus)?;
         // pretty_attribute(f, indent, "extra_data", self.extra_data)?;
+        pretty_obj_end(f, indent)?;
         Ok(())
     }
 }
@@ -203,10 +242,12 @@ impl Pretty for normal::BlockHeader {
     fn pretty<W>(self, f: &mut W, indent: usize) -> Result<()>
         where W: Write
     {
+        pretty_obj_start(f, indent)?;
         pretty_attribute(f, indent, "protocol_magic", style!(self.protocol_magic))?;
         pretty_attribute(f, indent, "previous_header", style!(self.previous_header))?;
-        pretty_object(f, indent, "body_proof", self.body_proof)?;
-        pretty_object(f, indent, "consensus", self.consensus)?;
+        pretty_attribute(f, indent, "body_proof", self.body_proof)?;
+        pretty_attribute(f, indent, "consensus", self.consensus)?;
+        pretty_obj_end(f, indent)?;
         Ok(())
     }
 }
@@ -215,8 +256,10 @@ impl Pretty for genesis::Consensus {
     fn pretty<W>(self, f: &mut W, indent: usize) -> Result<()>
         where W: Write
     {
+        pretty_obj_start(f, indent)?;
         pretty_attribute(f, indent, "epochid", style!(self.epoch).red().bold())?;
         pretty_attribute(f, indent, "chain_difficulty", style!(self.chain_difficulty))?;
+        pretty_obj_end(f, indent)?;
         Ok(())
     }
 }
@@ -224,6 +267,7 @@ impl Pretty for normal::Consensus {
     fn pretty<W>(self, f: &mut W, indent: usize) -> Result<()>
         where W: Write
     {
+        pretty_obj_start(f, indent)?;
         pretty_attribute(f, indent, "slotid", style!(self.slot_id))?;
         pretty_attribute(f, indent, "leader_key", style!(self.leader_key))?;
         pretty_attribute(f, indent, "chain_difficulty", style!(self.chain_difficulty))?;
@@ -235,7 +279,7 @@ impl Pretty for normal::Consensus {
                 // TODO
             }
         }
-
+        pretty_obj_end(f, indent)?;
         Ok(())
     }
 }
@@ -244,38 +288,54 @@ impl Pretty for normal::BodyProof {
     fn pretty<W>(self, f: &mut W, indent: usize) -> Result<()>
         where W: Write
     {
+        pretty_obj_start(f, indent)?;
         pretty_attribute(f, indent, "tx", self.tx)?;
         pretty_attribute(f, indent, "mpc", self.mpc)?;
         pretty_attribute(f, indent, "proxy_sk", style!(self.proxy_sk))?;
         pretty_attribute(f, indent, "update", style!(self.update))?;
-
+        pretty_obj_end(f, indent)?;
         Ok(())
     }
 }
 impl Pretty for tx::TxProof {
-    fn pretty<W>(self, f: &mut W, _: usize) -> Result<()>
+    fn pretty<W>(self, f: &mut W, indent: usize) -> Result<()>
         where W: Write
     {
-        writeln!(f, "{} {} {}", style!(self.number), style!(self.root), style!(self.witnesses_hash))
+        pretty_obj_start(f, indent)?;
+        pretty_attribute(f, indent, "number", style!(self.number))?;
+        pretty_attribute(f, indent, "root", style!(self.root))?;
+        pretty_attribute(f, indent, "witnesses_hash", style!(self.witnesses_hash))?;
+        pretty_obj_end(f, indent)?;
+        Ok(())
     }
 }
 impl Pretty for types::SscProof {
-    fn pretty<W>(self, f: &mut W, _: usize) -> Result<()>
+    fn pretty<W>(self, f: &mut W, indent: usize) -> Result<()>
         where W: Write
     {
+        pretty_obj_start(f, indent)?;
         match self {
             types::SscProof::Commitments(h1, h2) => {
-                write!(f, "{} {} ({})", style!(h1), style!(h2), style!("Commitments"))
+                pretty_attribute(f, indent, "h1", style!(h1))?;
+                pretty_attribute(f, indent, "h2", style!(h2))?;
+                pretty_attribute(f, indent, "type", style!("Commitments"))?;
             },
             types::SscProof::Openings(h1, h2) => {
-                write!(f, "{} {} ({})", style!(h1), style!(h2), style!("Openings"))
+                pretty_attribute(f, indent, "h1", style!(h1))?;
+                pretty_attribute(f, indent, "h2", style!(h2))?;
+                pretty_attribute(f, indent, "type", style!("Openings"))?;
             },
             types::SscProof::Shares(h1, h2) => {
-                write!(f, "{} {} ({})", style!(h1), style!(h2), style!("Shares"))
+                pretty_attribute(f, indent, "h1", style!(h1))?;
+                pretty_attribute(f, indent, "h2", style!(h2))?;
+                pretty_attribute(f, indent, "type", style!("Shares"))?;
             },
             types::SscProof::Certificate(h1) => {
-                write!(f, "{} ({})", style!(h1), style!("Certificate"))
+                pretty_attribute(f, indent, "h1", style!(h1))?;
+                pretty_attribute(f, indent, "type", style!("Shares"))?;
             }
         }
+        pretty_obj_end(f, indent)?;
+        Ok(())
     }
 }


### PR DESCRIPTION
This is a hack change so that the pretty print can be parsed as JSON. I thought JSON was a good mix of human-readable (intended goal of these commands I assume) and machine-readability. 

Here is a picture of the output

![image](https://user-images.githubusercontent.com/2608559/46655866-afac7900-cbe7-11e8-96d9-29829077e0bf.png)

⚠️We should have everything properly serializeable and then have this generated automatically⚠️
⚠️this seemed like it may be a non-trivial task so this is my (temporary?) fix⚠️ 