### PR TITLE
Fix iterating when 'from' is in a loose epoch

### DIFF
--- a/src/blockchain/iter/mod.rs
+++ b/src/blockchain/iter/mod.rs
@@ -88,7 +88,6 @@ impl<'a> Iter<'a> {
                     *from.clone(),
                     *to.clone()
                 ).unwrap(); // TODO
-                range.next();
                 IteratorType::Loose(storage, range)
             },
             Some(location) => {


### PR DESCRIPTION
Since both this iterator and storage::block::Range are inclusive of 'from', calling next() would cause the first block to be skipped.

This happened during `cardano-cli blockchain verify` when the testnet was in its first epoch.