### PR TITLE
Correctly report errors from wallet's load, save, delete log operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "clicolors-control 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -232,7 +232,7 @@ dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -320,7 +320,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -437,11 +437,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "lazycell"
@@ -812,7 +809,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -890,7 +887,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "0.15.17"
+version = "0.15.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -905,7 +902,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -976,7 +973,7 @@ name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1099,7 +1096,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1353,7 +1350,7 @@ dependencies = [
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
-"checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
+"checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
 "checksum lazycell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ddba4c30a78328befecec92fc94970e53b3ae385827d28620f0f5bb2493081e0"
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
@@ -1409,7 +1406,7 @@ dependencies = [
 "checksum smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "153ffa32fd170e9944f7e0838edf824a754ec4c1fc64746fcc9fe1f8fa602e5d"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
-"checksum syn 0.15.17 (registry+https://github.com/rust-lang/crates.io-index)" = "3391038ebc3e4ab24eb028cb0ef2f2dc4ba0cbf72ee895ed6a6fad730640b5bc"
+"checksum syn 0.15.18 (registry+https://github.com/rust-lang/crates.io-index)" = "90c39a061e2f412a9f869540471ab679e85e50c6b05604daf28bc3060f75c430"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum take 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b157868d8ac1f56b64604539990685fa7611d8fa9e5476cf0c02cf34d32917c5"
 "checksum tempfile 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "11ce2fe9db64b842314052e2421ac61a73ce41b898dc8e3750398b219c5fc1e0"

--- a/src/transaction/commands.rs
+++ b/src/transaction/commands.rs
@@ -402,7 +402,7 @@ pub fn input_select( term: &mut Term
     let outputs = staging.transaction().outputs().iter().map(|output| {
         output.into()
     }).collect::<Vec<_>>();
-    let inputs = list_input_inputs(term, root_dir.clone(), wallets);
+    let inputs = list_input_inputs(term, root_dir.clone(), wallets)?;
 
     let selection_result = match selection_type {
         SelectionPolicy::Blackjack(threshold) => {
@@ -456,10 +456,14 @@ fn find_input_in_all_utxos(term: &mut Term, root_dir: PathBuf, txid: TxId, index
     Err(Error::CannotFindInputsInAllLocalUtxos)
 }
 
-fn list_input_inputs(term: &mut Term, root_dir: PathBuf, wallets: Vec<WalletName>) -> Vec<::cardano::txutils::Input<ExtendedAddr>> {
+fn list_input_inputs(
+    term: &mut Term,
+    root_dir: PathBuf,
+    wallets: Vec<WalletName>
+) -> Result<Vec<::cardano::txutils::Input<ExtendedAddr>>, Error> {
     let mut inputs = Vec::new();
     for wallet in wallets {
-        let wallet = Wallet::load(root_dir.clone(), wallet);
+        let wallet = Wallet::load(root_dir.clone(), wallet)?;
         let state = wallet::utils::create_wallet_state_from_logs(term, &wallet, root_dir.clone(), wallet::state::lookup::accum::Accum::default());
 
         inputs.extend(state.utxos.iter().map(|(_, utxo)| {
@@ -473,5 +477,5 @@ fn list_input_inputs(term: &mut Term, root_dir: PathBuf, wallets: Vec<WalletName
         }))
     }
 
-    inputs
+    Ok(inputs)
 }

--- a/src/transaction/commands.rs
+++ b/src/transaction/commands.rs
@@ -1,151 +1,17 @@
-use std::{path::PathBuf, io::{self, Write}, iter, collections::BTreeMap, fmt, error};
+use std::{path::PathBuf, io::Write, iter, collections::BTreeMap};
 use utils::term::{Term, style::{Style}};
 use super::core::{self, StagingId, StagingTransaction};
-use super::super::blockchain::{self, Blockchain, BlockchainName};
+use super::error::Error;
+use super::super::blockchain::{Blockchain, BlockchainName};
 use super::super::wallet::{Wallets, Wallet, self, WalletName};
 use cardano::{
-    self,
     tx::{self, Tx, TxId, TxoPointer, TxInWitness},
-    coin::{self, Coin, sum_coins},
+    coin::{Coin, sum_coins},
     address::{ExtendedAddr},
     fee::{LinearFee, FeeAlgorithm},
     wallet::scheme::{SelectionPolicy},
 };
-use storage_units;
 
-#[derive(Debug)]
-pub enum Error {
-    IoError(::std::io::Error),
-    InvalidStagingId(core::staging_id::ParseStagingIdError),
-    CannotLoadBlockchain(blockchain::Error),
-    CannotLoadStagingTransaction(core::staging_transaction::StagingTransactionParseError),
-
-    CannotCreateNewTransaction(storage_units::append::Error),
-    CannotDestroyTransaction(storage_units::append::Error),
-    CannotSendTransactionNotFinalized(core::transaction::Error),
-    CannotSendTransactionInvalidTxAux(cardano::txbuild::Error),
-    CannotSendTransactionNotSent,
-    CannotSignTransactionNotFinalized(core::transaction::Error),
-    CannotSignTransactionInvalidTxAux(cardano::txbuild::Error),
-    CannotSignTransactionCannotAddSignature(core::staging_transaction::StagingUpdateError),
-    CannotReportStatusInvalidInputTotal(coin::Error),
-    CannotReportStatusInvalidOutputTotal(coin::Error),
-    CannotReportStatusInvalidTxBuilder(core::transaction::Error),
-    CannotReportStatusInvalidTx(cardano::txbuild::Error),
-    CannotReportStatusInvalidFee(cardano::fee::Error),
-    CannotAddInput(core::staging_transaction::StagingUpdateError),
-    CannotFindInputsInAllLocalUtxos,
-    CannotAddOutput(core::staging_transaction::StagingUpdateError),
-    CannotAddChange(core::staging_transaction::StagingUpdateError),
-    CannotRemoveInput(core::staging_transaction::StagingUpdateError),
-    CannotRemoveOutput(core::staging_transaction::StagingUpdateError),
-    CannotRemoveChange(core::staging_transaction::StagingUpdateError),
-    CannotFinalize(core::staging_transaction::StagingUpdateError),
-    CannotExportToFileCannotOpenOutFile(io::Error),
-    CannotExportToFile(::serde_yaml::Error),
-    CannotExportToStdout(::serde_yaml::Error),
-    CannotImportFromFileCannotOpenInputFile(io::Error),
-    CannotImportFromFile(::serde_yaml::Error),
-    CannotImportFromStdin(::serde_yaml::Error),
-    CannotImportStaging(core::staging_transaction::StagingUpdateError),
-
-    CannotInputSelectNoChangeOption,
-    CannotInputSelectSelectionFailed(cardano::input_selection::Error),
-    CannotInputSelectCannotAddInput(core::staging_transaction::StagingUpdateError),
-}
-impl From<::std::io::Error> for Error {
-    fn from(e: ::std::io::Error) -> Self { Error::IoError(e) }
-}
-impl From<core::staging_id::ParseStagingIdError> for Error {
-    fn from(e: core::staging_id::ParseStagingIdError) -> Self { Error::InvalidStagingId(e) }
-}
-impl From<blockchain::Error> for Error {
-    fn from(e: blockchain::Error) -> Self { Error::CannotLoadBlockchain(e) }
-}
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use self::Error::*;
-        match self {
-            IoError(_)                                 => write!(f, "I/O Error"),
-            InvalidStagingId(_)                        => write!(f, "Invalid Staging ID"),
-            CannotLoadBlockchain(_)                    => write!(f, "Cannot load the blockchain"),
-            CannotLoadStagingTransaction(_)            => write!(f, "Cannot load the staging transaction"),
-            CannotCreateNewTransaction(_)              => write!(f, "Cannot create a new Staging Transaction"),
-            CannotDestroyTransaction(_)                => write!(f, "Cannot destroy the Staging Transaction"),
-            CannotSendTransactionNotFinalized(_)       => write!(f, "Cannot send transaction, finalize it first"),
-            CannotSendTransactionInvalidTxAux(_)       => write!(f, "Cannot send transaction"),
-            CannotSendTransactionNotSent               => write!(f, "Cannot send transaction to any blockchain peers"),
-            CannotSignTransactionNotFinalized(_)       => write!(f, "Cannot sign transaction, finalize it first"),
-            CannotSignTransactionInvalidTxAux(_)       => write!(f, "Cannot sign transaction"),
-            CannotSignTransactionCannotAddSignature(_) => write!(f, "Cannot add signature to the transaction"),
-            CannotReportStatusInvalidInputTotal(_)     => write!(f, "Input total of the transaction is invalid"),
-            CannotReportStatusInvalidOutputTotal(_)    => write!(f, "Output total of the transaction is invalid"),
-            CannotReportStatusInvalidTxBuilder(_)      => write!(f, "Cannot gather the transaction status"),
-            CannotReportStatusInvalidTx(_)             => write!(f, "The transaction is not valid"),
-            CannotReportStatusInvalidFee(_)            => write!(f, "Fee computation returned an error"),
-            CannotAddInput(_)                          => write!(f, "Cannot add input to staging transaction"),
-            CannotFindInputsInAllLocalUtxos            => write!(f, "Cannot find inputs within the local UTxOs"),
-            CannotAddOutput(_)                         => write!(f, "Cannot add output to the staging transaction"),
-            CannotAddChange(_)                         => write!(f, "Cannot add change to the staging transaction"),
-            CannotRemoveInput(_)                       => write!(f, "Cannot remove input from the staging transaction"),
-            CannotRemoveOutput(_)                      => write!(f, "Cannot remove output from the staging transaction"),
-            CannotRemoveChange(_)                      => write!(f, "Cannot remove change from the staging transaction"),
-            CannotFinalize(_)                          => write!(f, "Cannot finalize the staging transaction"),
-            CannotExportToFileCannotOpenOutFile(_)     => write!(f, "Cannot export the staging transaction: cannot open output file"),
-            CannotExportToFile(_)                      => write!(f, "Cannot export the staging transaction to the output file"),
-            CannotExportToStdout(_)                    => write!(f, "Cannot export the staging transaction to the standard output"),
-            CannotImportFromFileCannotOpenInputFile(_) => write!(f, "Cannot import the staging transaction: cannot open input file"),
-            CannotImportFromFile(_)                    => write!(f, "Cannot import the staging transaction from the input file"),
-            CannotImportFromStdin(_)                   => write!(f, "Cannot import the staging transaction from the standard input"),
-            CannotImportStaging(_)                     => write!(f, "Cannot import the staging transaction: invalid or corrupted"),
-            CannotInputSelectNoChangeOption            => write!(f, "Add change before trying to run the input selection algorithm"),
-            CannotInputSelectSelectionFailed(_)        => write!(f, "Input selection algorithm failed to run"),
-            CannotInputSelectCannotAddInput(_)         => write!(f, "Cannot add input to the staging transaction"),
-        }
-    }
-}
-impl error::Error for Error {
-    fn cause(&self) -> Option<& error::Error> {
-        use self::Error::*;
-        match self {
-            IoError(ref err)                                 => Some(err),
-            InvalidStagingId(ref err)                        => Some(err),
-            CannotLoadStagingTransaction(ref err)            => Some(err),
-            CannotLoadBlockchain(ref err)                    => Some(err),
-            CannotCreateNewTransaction(ref err)              => Some(err),
-            CannotDestroyTransaction(ref err)                => Some(err),
-            CannotSendTransactionNotFinalized(ref err)       => Some(err),
-            CannotSendTransactionInvalidTxAux(ref err)       => Some(err),
-            CannotSendTransactionNotSent               => None,
-            CannotSignTransactionNotFinalized(ref err)       => Some(err),
-            CannotSignTransactionInvalidTxAux(ref err)       => Some(err),
-            CannotSignTransactionCannotAddSignature(ref err) => Some(err),
-            CannotReportStatusInvalidInputTotal(ref err)     => Some(err),
-            CannotReportStatusInvalidOutputTotal(ref err)    => Some(err),
-            CannotReportStatusInvalidTxBuilder(ref err)      => Some(err),
-            CannotReportStatusInvalidTx(ref err)             => Some(err),
-            CannotReportStatusInvalidFee(ref err)            => Some(err),
-            CannotAddInput(ref err)                          => Some(err),
-            CannotFindInputsInAllLocalUtxos            => None,
-            CannotAddOutput(ref err)                         => Some(err),
-            CannotAddChange(ref err)                         => Some(err),
-            CannotRemoveInput(ref err)                       => Some(err),
-            CannotRemoveOutput(ref err)                      => Some(err),
-            CannotRemoveChange(ref err)                      => Some(err),
-            CannotFinalize(ref err)                          => Some(err),
-            CannotExportToFileCannotOpenOutFile(ref err)     => Some(err),
-            CannotExportToFile(ref err)                      => Some(err),
-            CannotExportToStdout(ref err)                    => Some(err),
-            CannotImportFromFileCannotOpenInputFile(ref err) => Some(err),
-            CannotImportFromFile(ref err)                    => Some(err),
-            CannotImportFromStdin(ref err)                   => Some(err),
-            CannotImportStaging(ref err)                     => Some(err),
-            CannotInputSelectNoChangeOption            => None,
-            CannotInputSelectSelectionFailed(ref err)        => Some(err),
-            CannotInputSelectCannotAddInput(ref err)         => Some(err),
-        }
-    }
-}
 
 /// function to create a new empty transaction
 pub fn new( term: &mut Term

--- a/src/transaction/error.rs
+++ b/src/transaction/error.rs
@@ -1,0 +1,143 @@
+use super::core;
+use super::super::blockchain;
+use cardano::{
+    self,
+    coin,
+};
+use storage_units;
+
+use std::{io::{self, Write}, fmt, error};
+
+#[derive(Debug)]
+pub enum Error {
+    IoError(io::Error),
+    InvalidStagingId(core::staging_id::ParseStagingIdError),
+    CannotLoadBlockchain(blockchain::Error),
+    CannotLoadStagingTransaction(core::staging_transaction::StagingTransactionParseError),
+
+    CannotCreateNewTransaction(storage_units::append::Error),
+    CannotDestroyTransaction(storage_units::append::Error),
+    CannotSendTransactionNotFinalized(core::transaction::Error),
+    CannotSendTransactionInvalidTxAux(cardano::txbuild::Error),
+    CannotSendTransactionNotSent,
+    CannotSignTransactionNotFinalized(core::transaction::Error),
+    CannotSignTransactionInvalidTxAux(cardano::txbuild::Error),
+    CannotSignTransactionCannotAddSignature(core::staging_transaction::StagingUpdateError),
+    CannotReportStatusInvalidInputTotal(coin::Error),
+    CannotReportStatusInvalidOutputTotal(coin::Error),
+    CannotReportStatusInvalidTxBuilder(core::transaction::Error),
+    CannotReportStatusInvalidTx(cardano::txbuild::Error),
+    CannotReportStatusInvalidFee(cardano::fee::Error),
+    CannotAddInput(core::staging_transaction::StagingUpdateError),
+    CannotFindInputsInAllLocalUtxos,
+    CannotAddOutput(core::staging_transaction::StagingUpdateError),
+    CannotAddChange(core::staging_transaction::StagingUpdateError),
+    CannotRemoveInput(core::staging_transaction::StagingUpdateError),
+    CannotRemoveOutput(core::staging_transaction::StagingUpdateError),
+    CannotRemoveChange(core::staging_transaction::StagingUpdateError),
+    CannotFinalize(core::staging_transaction::StagingUpdateError),
+    CannotExportToFileCannotOpenOutFile(io::Error),
+    CannotExportToFile(::serde_yaml::Error),
+    CannotExportToStdout(::serde_yaml::Error),
+    CannotImportFromFileCannotOpenInputFile(io::Error),
+    CannotImportFromFile(::serde_yaml::Error),
+    CannotImportFromStdin(::serde_yaml::Error),
+    CannotImportStaging(core::staging_transaction::StagingUpdateError),
+
+    CannotInputSelectNoChangeOption,
+    CannotInputSelectSelectionFailed(cardano::input_selection::Error),
+    CannotInputSelectCannotAddInput(core::staging_transaction::StagingUpdateError),
+}
+impl From<::std::io::Error> for Error {
+    fn from(e: ::std::io::Error) -> Self { Error::IoError(e) }
+}
+impl From<core::staging_id::ParseStagingIdError> for Error {
+    fn from(e: core::staging_id::ParseStagingIdError) -> Self { Error::InvalidStagingId(e) }
+}
+impl From<blockchain::Error> for Error {
+    fn from(e: blockchain::Error) -> Self { Error::CannotLoadBlockchain(e) }
+}
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use self::Error::*;
+        match self {
+            IoError(_)                                 => write!(f, "I/O Error"),
+            InvalidStagingId(_)                        => write!(f, "Invalid Staging ID"),
+            CannotLoadBlockchain(_)                    => write!(f, "Cannot load the blockchain"),
+            CannotLoadStagingTransaction(_)            => write!(f, "Cannot load the staging transaction"),
+            CannotCreateNewTransaction(_)              => write!(f, "Cannot create a new Staging Transaction"),
+            CannotDestroyTransaction(_)                => write!(f, "Cannot destroy the Staging Transaction"),
+            CannotSendTransactionNotFinalized(_)       => write!(f, "Cannot send transaction, finalize it first"),
+            CannotSendTransactionInvalidTxAux(_)       => write!(f, "Cannot send transaction"),
+            CannotSendTransactionNotSent               => write!(f, "Cannot send transaction to any blockchain peers"),
+            CannotSignTransactionNotFinalized(_)       => write!(f, "Cannot sign transaction, finalize it first"),
+            CannotSignTransactionInvalidTxAux(_)       => write!(f, "Cannot sign transaction"),
+            CannotSignTransactionCannotAddSignature(_) => write!(f, "Cannot add signature to the transaction"),
+            CannotReportStatusInvalidInputTotal(_)     => write!(f, "Input total of the transaction is invalid"),
+            CannotReportStatusInvalidOutputTotal(_)    => write!(f, "Output total of the transaction is invalid"),
+            CannotReportStatusInvalidTxBuilder(_)      => write!(f, "Cannot gather the transaction status"),
+            CannotReportStatusInvalidTx(_)             => write!(f, "The transaction is not valid"),
+            CannotReportStatusInvalidFee(_)            => write!(f, "Fee computation returned an error"),
+            CannotAddInput(_)                          => write!(f, "Cannot add input to staging transaction"),
+            CannotFindInputsInAllLocalUtxos            => write!(f, "Cannot find inputs within the local UTxOs"),
+            CannotAddOutput(_)                         => write!(f, "Cannot add output to the staging transaction"),
+            CannotAddChange(_)                         => write!(f, "Cannot add change to the staging transaction"),
+            CannotRemoveInput(_)                       => write!(f, "Cannot remove input from the staging transaction"),
+            CannotRemoveOutput(_)                      => write!(f, "Cannot remove output from the staging transaction"),
+            CannotRemoveChange(_)                      => write!(f, "Cannot remove change from the staging transaction"),
+            CannotFinalize(_)                          => write!(f, "Cannot finalize the staging transaction"),
+            CannotExportToFileCannotOpenOutFile(_)     => write!(f, "Cannot export the staging transaction: cannot open output file"),
+            CannotExportToFile(_)                      => write!(f, "Cannot export the staging transaction to the output file"),
+            CannotExportToStdout(_)                    => write!(f, "Cannot export the staging transaction to the standard output"),
+            CannotImportFromFileCannotOpenInputFile(_) => write!(f, "Cannot import the staging transaction: cannot open input file"),
+            CannotImportFromFile(_)                    => write!(f, "Cannot import the staging transaction from the input file"),
+            CannotImportFromStdin(_)                   => write!(f, "Cannot import the staging transaction from the standard input"),
+            CannotImportStaging(_)                     => write!(f, "Cannot import the staging transaction: invalid or corrupted"),
+            CannotInputSelectNoChangeOption            => write!(f, "Add change before trying to run the input selection algorithm"),
+            CannotInputSelectSelectionFailed(_)        => write!(f, "Input selection algorithm failed to run"),
+            CannotInputSelectCannotAddInput(_)         => write!(f, "Cannot add input to the staging transaction"),
+        }
+    }
+}
+impl error::Error for Error {
+    fn cause(&self) -> Option<& error::Error> {
+        use self::Error::*;
+        match self {
+            IoError(ref err)                                 => Some(err),
+            InvalidStagingId(ref err)                        => Some(err),
+            CannotLoadStagingTransaction(ref err)            => Some(err),
+            CannotLoadBlockchain(ref err)                    => Some(err),
+            CannotCreateNewTransaction(ref err)              => Some(err),
+            CannotDestroyTransaction(ref err)                => Some(err),
+            CannotSendTransactionNotFinalized(ref err)       => Some(err),
+            CannotSendTransactionInvalidTxAux(ref err)       => Some(err),
+            CannotSendTransactionNotSent               => None,
+            CannotSignTransactionNotFinalized(ref err)       => Some(err),
+            CannotSignTransactionInvalidTxAux(ref err)       => Some(err),
+            CannotSignTransactionCannotAddSignature(ref err) => Some(err),
+            CannotReportStatusInvalidInputTotal(ref err)     => Some(err),
+            CannotReportStatusInvalidOutputTotal(ref err)    => Some(err),
+            CannotReportStatusInvalidTxBuilder(ref err)      => Some(err),
+            CannotReportStatusInvalidTx(ref err)             => Some(err),
+            CannotReportStatusInvalidFee(ref err)            => Some(err),
+            CannotAddInput(ref err)                          => Some(err),
+            CannotFindInputsInAllLocalUtxos            => None,
+            CannotAddOutput(ref err)                         => Some(err),
+            CannotAddChange(ref err)                         => Some(err),
+            CannotRemoveInput(ref err)                       => Some(err),
+            CannotRemoveOutput(ref err)                      => Some(err),
+            CannotRemoveChange(ref err)                      => Some(err),
+            CannotFinalize(ref err)                          => Some(err),
+            CannotExportToFileCannotOpenOutFile(ref err)     => Some(err),
+            CannotExportToFile(ref err)                      => Some(err),
+            CannotExportToStdout(ref err)                    => Some(err),
+            CannotImportFromFileCannotOpenInputFile(ref err) => Some(err),
+            CannotImportFromFile(ref err)                    => Some(err),
+            CannotImportFromStdin(ref err)                   => Some(err),
+            CannotImportStaging(ref err)                     => Some(err),
+            CannotInputSelectNoChangeOption            => None,
+            CannotInputSelectSelectionFailed(ref err)        => Some(err),
+            CannotInputSelectCannotAddInput(ref err)         => Some(err),
+        }
+    }
+}

--- a/src/transaction/error.rs
+++ b/src/transaction/error.rs
@@ -1,12 +1,15 @@
 use super::core;
-use super::super::blockchain;
+use super::super::{
+    blockchain,
+    wallet,
+};
 use cardano::{
     self,
     coin,
 };
 use storage_units;
 
-use std::{io::{self, Write}, fmt, error};
+use std::{fmt, io, error};
 
 #[derive(Debug)]
 pub enum Error {
@@ -14,6 +17,7 @@ pub enum Error {
     InvalidStagingId(core::staging_id::ParseStagingIdError),
     CannotLoadBlockchain(blockchain::Error),
     CannotLoadStagingTransaction(core::staging_transaction::StagingTransactionParseError),
+    CannotLoadWallet(wallet::Error),
 
     CannotCreateNewTransaction(storage_units::append::Error),
     CannotDestroyTransaction(storage_units::append::Error),
@@ -57,6 +61,9 @@ impl From<core::staging_id::ParseStagingIdError> for Error {
 impl From<blockchain::Error> for Error {
     fn from(e: blockchain::Error) -> Self { Error::CannotLoadBlockchain(e) }
 }
+impl From<wallet::Error> for Error {
+    fn from(e: wallet::Error) -> Self { Error::CannotLoadWallet(e) }
+}
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use self::Error::*;
@@ -65,6 +72,7 @@ impl fmt::Display for Error {
             InvalidStagingId(_)                        => write!(f, "Invalid Staging ID"),
             CannotLoadBlockchain(_)                    => write!(f, "Cannot load the blockchain"),
             CannotLoadStagingTransaction(_)            => write!(f, "Cannot load the staging transaction"),
+            CannotLoadWallet(_)                        => write!(f, "Cannot load wallet"),
             CannotCreateNewTransaction(_)              => write!(f, "Cannot create a new Staging Transaction"),
             CannotDestroyTransaction(_)                => write!(f, "Cannot destroy the Staging Transaction"),
             CannotSendTransactionNotFinalized(_)       => write!(f, "Cannot send transaction, finalize it first"),
@@ -107,6 +115,7 @@ impl error::Error for Error {
             InvalidStagingId(ref err)                        => Some(err),
             CannotLoadStagingTransaction(ref err)            => Some(err),
             CannotLoadBlockchain(ref err)                    => Some(err),
+            CannotLoadWallet(ref err)                        => Some(err),
             CannotCreateNewTransaction(ref err)              => Some(err),
             CannotDestroyTransaction(ref err)                => Some(err),
             CannotSendTransactionNotFinalized(ref err)       => Some(err),

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -1,2 +1,3 @@
 pub mod core;
 pub mod commands;
+pub mod error;

--- a/src/wallet/commands.rs
+++ b/src/wallet/commands.rs
@@ -98,7 +98,7 @@ where
     let wallet = Wallet::new(root_dir, name, config, encrypted_xprv, public_key);
 
     // 6. save the wallet
-    wallet.save();
+    wallet.save()?;
 
     term.success(&format!("wallet `{}' successfully created.\n", &wallet.name)).unwrap();
 
@@ -172,7 +172,7 @@ where
     let wallet = Wallet::new(root_dir, name, config, encrypted_xprv, public_key);
 
     // 6. save the wallet
-    wallet.save();
+    wallet.save()?;
 
     term.success(&format!("wallet `{}' successfully recovered.\n", &wallet.name)).unwrap();
 
@@ -236,7 +236,7 @@ pub fn attach(
 
     // 3. save the attached wallet
     wallet.config.attached_blockchain = Some(blockchain_name.as_ref().to_owned());
-    wallet.save();
+    wallet.save()?;
 
     term.success("Wallet successfully attached to blockchain.\n").unwrap();
 
@@ -261,11 +261,11 @@ pub fn detach(
     );
 
     // 2. delete the wallet log
-    wallet.delete_log().map_err(|e| Error::WalletDeleteLogFailed(e))?;
+    wallet.delete_log()?;
 
     wallet.config.attached_blockchain = None;
 
-    wallet.save();
+    wallet.save()?;
 
     term.success("Wallet successfully attached to blockchain.\n").unwrap();
 

--- a/src/wallet/commands.rs
+++ b/src/wallet/commands.rs
@@ -190,7 +190,7 @@ pub fn destroy(
     name: WalletName,
 ) -> Result<()> {
     // load the wallet
-    let wallet = Wallet::load(&root_dir, name);
+    let wallet = Wallet::load(&root_dir, name)?;
 
     writeln!(term, "You are about to destroy your wallet {}.
 This means that all the data associated to this wallet will be deleted on this device.
@@ -224,7 +224,7 @@ pub fn attach(
     blockchain_name: BlockchainName
 ) -> Result<()> {
     // load the wallet
-    let mut wallet = Wallet::load(&root_dir, name);
+    let mut wallet = Wallet::load(&root_dir, name)?;
 
     // 1. is the wallet already attached
     if let Some(ref bn) = wallet.config.attached_blockchain {
@@ -249,7 +249,7 @@ pub fn detach(
     name: WalletName,
 ) -> Result<()> {
     // load the wallet
-    let mut wallet = Wallet::load(&root_dir, name);
+    let mut wallet = Wallet::load(&root_dir, name)?;
 
     let blockchainname = wallet.config.attached_blockchain().unwrap();
 
@@ -278,7 +278,7 @@ pub fn status(
     name: WalletName,
 ) -> Result<()> {
     // load the wallet
-    let wallet = Wallet::load(root_dir.clone(), name);
+    let wallet = Wallet::load(root_dir.clone(), name)?;
 
     if let Some(ref blk_name) = &wallet.config.attached_blockchain {
         term.simply("Wallet ").unwrap();
@@ -336,7 +336,7 @@ pub fn log(term: &mut Term,
     pretty: bool,
 ) -> Result<()> {
     // load the wallet
-    let wallet = Wallet::load(root_dir.clone(), name);
+    let wallet = Wallet::load(root_dir.clone(), name)?;
 
     let mut state = create_wallet_state_from_logs(term, &wallet, root_dir, lookup::accum::Accum::default());
 
@@ -350,7 +350,7 @@ pub fn utxos(term: &mut Term,
     name: WalletName,
 ) -> Result<()> {
     // load the wallet
-    let wallet = Wallet::load(root_dir.clone(), name);
+    let wallet = Wallet::load(root_dir.clone(), name)?;
 
     let state = create_wallet_state_from_logs(term, &wallet, root_dir, lookup::accum::Accum::default());
 
@@ -364,7 +364,7 @@ pub fn sync(term: &mut Term,
     name: WalletName,
 ) -> Result<()> {
     // 0. load the wallet
-    let wallet = Wallet::load(root_dir.clone(), name);
+    let wallet = Wallet::load(root_dir.clone(), name)?;
 
     let blockchainname = wallet.config.attached_blockchain().unwrap();
 
@@ -400,7 +400,7 @@ pub fn address(
     index: u32,
 ) -> Result<()> {
     // load the wallet
-    let wallet = Wallet::load(root_dir.clone(), name);
+    let wallet = Wallet::load(root_dir.clone(), name)?;
 
     let addr = match wallet.config.hdwallet_model {
         HDWalletModel::BIP44 => {

--- a/src/wallet/error.rs
+++ b/src/wallet/error.rs
@@ -27,6 +27,7 @@ pub enum Error {
     WalletLogNotFound,
     WalletLogError(log::Error),
     AttachAlreadyAttached(String),
+    WalletsLoadFailed(io::Error),
 }
 impl From<io::Error> for Error {
     fn from(e: io::Error) -> Self { Error::IoError(e) }
@@ -72,6 +73,7 @@ impl fmt::Display for Error {
             Error::WalletLogNotFound                       => write!(f, "No wallet log Found"),
             Error::WalletLogError(_)                       => write!(f, "Error with the wallet log"),
             Error::AttachAlreadyAttached(bn)               => write!(f, "Wallet already attached to blockchain `{}'", bn),
+            Error::WalletsLoadFailed(_)                    => write!(f, "Cannot load wallets"),
         }
     }
 }
@@ -95,6 +97,7 @@ impl error::Error for Error {
             Error::WalletLogNotFound                       => None,
             Error::WalletLogError(ref err)                 => Some(err),
             Error::AttachAlreadyAttached(_)                => None,
+            Error::WalletsLoadFailed(ref err)              => Some(err),
         }
     }
 }

--- a/src/wallet/error.rs
+++ b/src/wallet/error.rs
@@ -10,20 +10,26 @@ use super::state::log;
 /// wallet errors
 #[derive(Debug)]
 pub enum Error {
+    IoError(io::Error),
     CannotLoadBlockchain(blockchain::Error),
     CoinError(coin::Error),
     Bip44AddressError(bip44::Error),
     CannotRetrievePrivateKey(hdwallet::Error),
     CannotRetrievePrivateKeyInvalidPassword,
     CannotRecoverFromDaedalusMnemonics(rindex::Error),
-    BadWalletConfig(PathBuf, serde_yaml::Error),
+    ConfigReadFailed(PathBuf, serde_yaml::Error),
+    ConfigWriteFailed(PathBuf, serde_yaml::Error),
     WalletLoadFailed(io::Error),
+    WalletSaveFailed(io::Error),
     WalletDestroyFailed(io::Error),
     WalletDeleteLogFailed(io::Error),
     WalletLogAlreadyLocked(u32),
     WalletLogNotFound,
     WalletLogError(log::Error),
     AttachAlreadyAttached(String),
+}
+impl From<io::Error> for Error {
+    fn from(e: io::Error) -> Self { Error::IoError(e) }
 }
 impl From<blockchain::Error> for Error {
     fn from(e: blockchain::Error) -> Self { Error::CannotLoadBlockchain(e) }
@@ -49,14 +55,17 @@ impl From<log::Error> for Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
+            Error::IoError(_)                              => write!(f, "I/O error occurred"),
             Error::CannotLoadBlockchain(_)                 => write!(f, "Cannot load blockchain"),
             Error::CoinError(_)                            => write!(f, "Error with coin calculations"),
             Error::Bip44AddressError(_)                    => write!(f, "Error with BIP44 account addressing"),
             Error::CannotRetrievePrivateKey(_)             => write!(f, "Unsupported private key serialisation"),
             Error::CannotRetrievePrivateKeyInvalidPassword => write!(f, "Invalid spending password"),
             Error::CannotRecoverFromDaedalusMnemonics(_)   => write!(f, "Cannot recover the wallet from Daedalus mnemonics"),
-            Error::BadWalletConfig(ref path, _)            => write!(f, "Error in configuration file `{}`", path.to_string_lossy()),
+            Error::ConfigReadFailed(ref path, _)           => write!(f, "Failed to read wallet configuration file `{}`", path.to_string_lossy()),
+            Error::ConfigWriteFailed(ref path, _)          => write!(f, "Failed to write wallet configuration to directory `{}`", path.to_string_lossy()),
             Error::WalletLoadFailed(_)                     => write!(f, "Cannot load the wallet"),
+            Error::WalletSaveFailed(_)                     => write!(f, "Cannot save the wallet"),
             Error::WalletDestroyFailed(_)                  => write!(f, "Cannot destroy the wallet"),
             Error::WalletDeleteLogFailed(_)                => write!(f, "Cannot delete the wallet's log"),
             Error::WalletLogAlreadyLocked(pid)             => write!(f, "Wallet is already being used by another process (process id: {})", pid),
@@ -69,14 +78,17 @@ impl fmt::Display for Error {
 impl error::Error for Error {
     fn cause(&self) -> Option<& error::Error> {
         match self {
+            Error::IoError(ref err)                        => Some(err),
             Error::CannotLoadBlockchain(ref err)           => Some(err),
             Error::CoinError(ref err)                      => Some(err),
             Error::Bip44AddressError(ref err)              => Some(err),
             Error::CannotRetrievePrivateKey(ref err)       => Some(err),
             Error::CannotRetrievePrivateKeyInvalidPassword => None,
             Error::CannotRecoverFromDaedalusMnemonics(ref err) => Some(err),
-            Error::BadWalletConfig(_, ref err)             => Some(err),
+            Error::ConfigReadFailed(_, ref err)            => Some(err),
+            Error::ConfigWriteFailed(_, ref err)           => Some(err),
             Error::WalletLoadFailed(ref err)               => Some(err),
+            Error::WalletSaveFailed(ref err)               => Some(err),
             Error::WalletDestroyFailed(ref err)            => Some(err),
             Error::WalletDeleteLogFailed(ref err)          => Some(err),
             Error::WalletLogAlreadyLocked(_)               => None,

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -286,7 +286,14 @@ impl Wallets {
 
             if let Some(name) = WalletName::new(s) {
                 // load the wallet
-                let wallet = Wallet::load(root_dir.clone(), name)?;
+                let wallet = match Wallet::load(root_dir.clone(), name) {
+                    Ok(wallet) => wallet,
+                    Err(e) => {
+                        warn!("failed to load wallet in directory {:?}: {:?}",
+                            entry.path(), e);
+                        continue;
+                    }
+                };
                 wallets.insert(wallet.name.clone(), wallet);
             } else {
                 warn!("unexpected file in wallet directory: {:?}", entry.path());

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -178,12 +178,16 @@ impl Wallet {
         let mut key = Vec::with_capacity(150);
         file.read_to_end(&mut key)?;
 
-        let mut file = fs::File::open(&dir.join(WALLET_PUBLIC_KEY))?;
-        let mut pubkey = [0;XPUB_SIZE];
-        file.read_exact(&mut pubkey)?;
-        let xpub = XPub::from_bytes(pubkey);
+        let xpub = match fs::File::open(&dir.join(WALLET_PUBLIC_KEY)) {
+            Err(_err) => None, // TODO, check for file does not exists
+            Ok(mut file) => {
+                let mut key = [0;XPUB_SIZE];
+                file.read_exact(&mut key)?;
+                Some(XPub::from_bytes(key))
+            }
+        };
 
-        Ok(Self::new(root_dir, name, cfg, key, Some(xpub)))
+        Ok(Self::new(root_dir, name, cfg, key, xpub))
     }
 
     /// lock the LOG file of the wallet for Read and/or Write operations


### PR DESCRIPTION
Removed lots of `.unwrap()` from file I/O operations in methods of `Wallet` and `Wallets`, returning errors instead for graceful reporting.