### PR TITLE
wallet: Improve LogLock

### DIFF
--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -193,7 +193,7 @@ impl Wallet {
     /// lock the LOG file of the wallet for Read and/or Write operations
     pub fn log(&self) -> Result<LogLock> {
         let dir = config::directory(self.root_dir.clone(), &self.name.as_dirname());
-        let lock = LogLock::acquire_wallet_log_lock(dir)?;
+        let lock = LogLock::acquire(dir)?;
 
         let writer = LogWriter::open(lock)?;
         Ok(writer.release_lock())
@@ -210,9 +210,9 @@ impl Wallet {
     }
 
     fn delete_log_internal(&self) -> Result<()> {
-        let dir = config::directory(self.root_dir.clone(), &self.name.as_dirname());
-        let lock = LogLock::acquire_wallet_log_lock(dir.clone())?;
-        Ok(lock.delete_wallet_log_lock(dir)?)
+        let dir = config::directory(&self.root_dir, &self.name.as_dirname());
+        let lock = LogLock::acquire(&dir)?;
+        Ok(lock.delete_wallet_log()?)
     }
 
     /// convenient function to reconstruct a BIP44 wallet from the encrypted key and password


### PR DESCRIPTION
It's probably not safe to have the API user pass back the log file path to
delete, expecting it to be the same as the locked log file.
Better to remember the path inside `LogLock`.
Shortened the method names and named the log deletion method
`delete_wallet_log` because it's the log file that is being deleted.