### PR TITLE
Remove panics in blockchain iteration commands

### DIFF
--- a/src/blockchain/commands.rs
+++ b/src/blockchain/commands.rs
@@ -244,7 +244,7 @@ pub fn log( term: &mut Term
         blockchain.load_tip().0.hash
     };
 
-    for block in storage::iter::ReverseIter::from(&blockchain.storage, from).unwrap() {
+    for block in storage::iter::ReverseIter::from(&blockchain.storage, from)? {
         use utils::pretty::Pretty;
 
         block.pretty(term, 0)?;
@@ -460,7 +460,7 @@ pub fn verify_chain( term: &mut Term
     let mut nr_blocks = 0;
     let mut chain_state = cardano::block::ChainState::new(&genesis_data);
 
-    for res in blockchain.iter_to_tip(blockchain.config.genesis.clone()).unwrap() {
+    for res in blockchain.iter_to_tip(blockchain.config.genesis.clone())? {
         let (_raw_blk, blk) = res.unwrap();
         nr_blocks += 1;
         let hash = blk.get_header().compute_hash();

--- a/src/blockchain/error.rs
+++ b/src/blockchain/error.rs
@@ -1,3 +1,4 @@
+use super::iter;
 use std::{io, fmt, error, path::PathBuf};
 use cardano::block::{self, HeaderHash};
 use cardano_storage;
@@ -7,6 +8,7 @@ use cbor_event;
 pub enum Error {
     IoError(io::Error),
     StorageError(cardano_storage::Error),
+    IterError(iter::Error),
 
     NewCannotInitializeBlockchainDirectory(cardano_storage::Error),
 
@@ -35,6 +37,10 @@ impl From<io::Error> for Error {
     fn from(e: io::Error) -> Self { Error::IoError(e) }
 }
 
+impl From<iter::Error> for Error {
+    fn from(e: iter::Error) -> Self { Error::IterError(e) }
+}
+
 impl From<cardano_storage::Error> for Error {
     fn from(e: cardano_storage::Error) -> Self { Error::StorageError(e) }
 }
@@ -46,6 +52,7 @@ impl fmt::Display for Error {
         match self {
             Error::IoError(_) => write!(f, "I/O Error"),
             Error::StorageError(_) => write!(f, "Storage Error"),
+            Error::IterError(_) => write!(f, "Error iterating blockchain"),
 
             Error::NewCannotInitializeBlockchainDirectory(_) => write!(f, "Cannot Initialise the blockchain directory"),
             Error::LoadConfigFileNotFound(p)                 => write!(f, "Cannot load blockchain configuration from `{}`; is the blockchain initialized?", p.to_string_lossy()),
@@ -69,6 +76,7 @@ impl error::Error for Error {
         match self {
             Error::IoError(ref err) => Some(err),
             Error::StorageError(ref err) => Some(err),
+            Error::IterError(ref err) => Some(err),
             Error::NewCannotInitializeBlockchainDirectory(ref err) => Some(err),
             Error::ListBlockchainInvalidName(ref err) => Some(err),
             Error::CatMalformedBlock(ref err) => Some(err),

--- a/src/blockchain/iter/error.rs
+++ b/src/blockchain/iter/error.rs
@@ -1,3 +1,5 @@
+use cardano::block::HeaderHash;
+
 use std::{fmt, error};
 
 #[derive(Debug)]
@@ -5,6 +7,7 @@ pub enum Error {
     IoError(::std::io::Error),
     CborError(::cbor_event::Error),
     StorageError(::cardano_storage::Error),
+    InvalidBlockHash(HeaderHash),
 }
 impl From<::std::io::Error> for Error {
     fn from(e: ::std::io::Error) -> Self { Error::IoError(e) }
@@ -24,6 +27,9 @@ impl fmt::Display for Error {
             Error::IoError(_)      => write!(f, "I/O Error"),
             Error::CborError(_)    => write!(f, "Encoding error (CBOR)"),
             Error::StorageError(_) => write!(f, "Storage error"),
+            Error::InvalidBlockHash(h) => {
+                write!(f, "Invalid block hash {}", h)
+            }
         }
     }
 }
@@ -33,6 +39,7 @@ impl error::Error for Error {
             Error::IoError(ref err) => Some(err),
             Error::CborError(ref err) => Some(err),
             Error::StorageError(ref err) => Some(err),
+            Error::InvalidBlockHash(_) => None,
         }
     }
 }

--- a/src/blockchain/iter/mod.rs
+++ b/src/blockchain/iter/mod.rs
@@ -81,7 +81,9 @@ pub struct Iter<'a> {
 impl<'a> Iter<'a> {
     pub fn new(storage: &'a Storage, from: HeaderHash, to: HeaderHash) -> Result<Self> {
         let iterator = match storage::block_location(&storage, &from) {
-            None => panic!(),
+            None => {
+                return Err(Error::InvalidBlockHash(from));
+            }
             Some(storage::BlockLocation::Loose) => {
                 let mut range = storage::iter::Range::new(
                     storage,


### PR DESCRIPTION
Convert some more panicky code in `blockchain` sub-commands to report errors instead.