### PR TITLE
Fixed decode_signed_tx() to correclty display a cross-mark instead of…

### DIFF
--- a/src/debug/mod.rs
+++ b/src/debug/mod.rs
@@ -70,7 +70,7 @@ pub fn decode_signed_tx() {
         let valid = if signature_ok {
             emoji::CHECK_MARK
         } else {
-            emoji::CHECK_MARK
+            emoji::CROSS_MARK
         };
         println!(" - input ({}) {}.{} {}", i, style!(&input.id), style!(&input.index), valid);
     }


### PR DESCRIPTION
… a check-mark when an input is invalid.