### PR TITLE
Implement raw output for blockchain cat command.

### DIFF
--- a/src/blockchain/commands.rs
+++ b/src/blockchain/commands.rs
@@ -12,6 +12,7 @@ use super::{iter, peer, Blockchain, Result, Error, BlockchainName};
 use cardano::{
     self,
     block::{BlockDate, HeaderHash, RawBlock},
+    util::hex,
 };
 
 /// function to create and initialize a given new blockchain
@@ -335,12 +336,21 @@ fn get_block(blockchain: &Blockchain, hash: &HeaderHash) -> Result<RawBlock>
     }
 }
 
+arg_enum!{
+    #[derive(Debug)]
+    pub enum RawEncodeType {
+        Hex,
+        Base64,
+    }
+}
+
 pub fn cat( term: &mut Term
           , root_dir: PathBuf
           , name: BlockchainName
           , hash: HeaderHash
           , no_parse: bool
           , debug: bool
+          , output_raw: Option<RawEncodeType>
           )
     -> Result<()>
 {
@@ -351,13 +361,23 @@ pub fn cat( term: &mut Term
         ::std::io::stdout().write(rblk.as_ref())?;
         ::std::io::stdout().flush()?;
     } else {
-        use utils::pretty::Pretty;
+        match output_raw {
+            Some(RawEncodeType::Hex)    => {
+                write!(term, "{}", hex::encode(rblk.as_ref()))?;
+            },
+            Some(RawEncodeType::Base64) => {
+                write!(term, "{}", base64::encode(rblk.as_ref()))?;
+            },
+            None => {
+                use utils::pretty::Pretty;
 
-        let blk = rblk.decode().map_err(Error::CatMalformedBlock)?;
-        if debug {
-            writeln!(term, "{:#?}", blk)?;
-        } else {
-            blk.pretty(term, 0)?;
+                let blk = rblk.decode().map_err(Error::CatMalformedBlock)?;
+                if debug {
+                    writeln!(term, "{:#?}", blk)?;
+                } else {
+                    blk.pretty(term, 0)?;
+                }
+            },
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -376,8 +376,13 @@ fn subcommand_blockchain<'a>(mut term: term::Term, root_dir: PathBuf, matches: &
             let hash = blockchain_argument_headhash_match(&mut term, matches, "HASH_BLOCK");
             let no_parse = matches.is_present("BLOCK_NO_PARSE");
             let debug = matches.is_present("DEBUG");
+            let encode_type = if matches.is_present("OUTPUT_RAW") {
+                Some(value_t_or_exit!(matches.value_of("OUTPUT_RAW"), blockchain::commands::RawEncodeType))
+            } else {
+                None
+            };
 
-            blockchain::commands::cat(&mut term, root_dir, name, hash, no_parse, debug)
+            blockchain::commands::cat(&mut term, root_dir, name, hash, no_parse, debug, encode_type)
                 .unwrap_or_else(|e| term.fail_with(e));
         },
         ("status", Some(matches)) => {
@@ -517,6 +522,12 @@ fn blockchain_commands_definition<'a, 'b>() -> App<'a, 'b> {
             .arg(Arg::with_name("DEBUG")
                 .long("debug")
                 .help("dump the block in debug format")
+            )
+            .arg(Arg::from_usage("[OUTPUT_RAW] --output-raw=[format]")
+                .help("dump the block in the specified raw format format")
+                .possible_values(&blockchain::commands::RawEncodeType::variants())
+                .case_insensitive(true)
+                .conflicts_with_all(&["DEBUG", "BLOCK_NO_PARSE"])
             )
         )
         .subcommand(SubCommand::with_name("status")


### PR DESCRIPTION
Hexadecimal and base64 are supported in this commit.

usage: --output-raw=hex, --output-raw=base64

resolves input-output-hk/cardano-cli#47