### PR TITLE
fix dialoguer lost commit (this is due to a rebase of the PR)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,9 +118,9 @@ dependencies = [
  "cardano-storage 0.1.0",
  "cbor_event 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "console 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "console 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cryptoxide 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "dialoguer 0.1.0 (git+https://github.com/primetype/dialoguer?rev=bcd067b454bfc03b2a3dc5d4be314c9852265fac)",
+ "dialoguer 0.3.0 (git+https://github.com/primetype/dialoguer?rev=2f5b8b96cc1388834915f65fca59b7c14fde0835)",
  "dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "exe-common 0.1.0",
@@ -187,6 +187,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clicolors-control"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +212,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "clicolors-control 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termios 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "console"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clicolors-control 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -257,10 +284,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "dialoguer"
-version = "0.1.0"
-source = "git+https://github.com/primetype/dialoguer?rev=bcd067b454bfc03b2a3dc5d4be314c9852265fac#bcd067b454bfc03b2a3dc5d4be314c9852265fac"
+version = "0.3.0"
+source = "git+https://github.com/primetype/dialoguer?rev=2f5b8b96cc1388834915f65fca59b7c14fde0835#2f5b8b96cc1388834915f65fca59b7c14fde0835"
 dependencies = [
  "console 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1332,15 +1360,17 @@ dependencies = [
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum clicolors-control 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1f84dec9bc083ce2503908cd305af98bd363da6f54bf8d4bf0ac14ee749ad5d1"
+"checksum clicolors-control 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c993375952e681ff6d18190b0f1db399cacce4f488ac2f46f36792506e6b90a8"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum console 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ecd48adf136733979b49e15bc3b4c43cc0d3c85ece7bd08e6daa414c6fcb13e6"
+"checksum console 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3949ee3155c602df08e8e9a557f209e196829174535d6a58b555ab77a9140573"
 "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
 "checksum crossbeam-deque 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4fe1b6f945f824c7a25afe44f62e25d714c0cc523f8e99d8db5cd1026e1269d3"
 "checksum crossbeam-epoch 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2449aaa4ec7ef96e5fb24db16024b935df718e9ae1cec0a1e68feeca2efca7b8"
 "checksum crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "677d453a17e8bd2b913fa38e8b9cf04bcdbb5be790aa294f2389661d72036015"
 "checksum crossbeam-utils 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c55913cc2799171a550e307918c0a360e8c16004820291bf3b638969b4a01816"
 "checksum cryptoxide 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc9be687df90da186ed5c6ada0b6b4d69f5ad914071870bc5d41277377d30427"
-"checksum dialoguer 0.1.0 (git+https://github.com/primetype/dialoguer?rev=bcd067b454bfc03b2a3dc5d4be314c9852265fac)" = "<none>"
+"checksum dialoguer 0.3.0 (git+https://github.com/primetype/dialoguer?rev=2f5b8b96cc1388834915f65fca59b7c14fde0835)" = "<none>"
 "checksum dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "88972de891f6118092b643d85a0b28e0678e0f948d7f879aa32f2d5aafe97d2a"
 "checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
 "checksum env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)" = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ The Cardano command line interface:
 
 
 [dependencies]
-console = "0.6.2"
-dialoguer = { git = "https://github.com/primetype/dialoguer", rev = "bcd067b454bfc03b2a3dc5d4be314c9852265fac" }
+console = "0.7"
+dialoguer = { git = "https://github.com/primetype/dialoguer", rev = "2f5b8b96cc1388834915f65fca59b7c14fde0835" }
 indicatif = "0.9"
 log = "0.4"
 dirs = "1.0"

--- a/src/blockchain/commands.rs
+++ b/src/blockchain/commands.rs
@@ -101,9 +101,7 @@ wallets won't be able to interact with this blockchain.",
         ::console::style(&blockchain.name).bold().red(),
     )?;
 
-    let confirmation = ::dialoguer::Confirmation::new("Are you sure?")
-        .use_line_input(true)
-        .clear(false)
+    let confirmation = ::dialoguer::Confirmation::new().with_text("Are you sure?")
         .default(false)
         .interact()?;
     if confirmation {

--- a/src/utils/prompt/mnemonics.rs
+++ b/src/utils/prompt/mnemonics.rs
@@ -7,16 +7,15 @@ fn interactive_input_word<D>(term: &mut Term, dic: &D, idx: usize, count: usize)
     where D: Language
 {
     loop {
-        let word = Input::new(&format!("mnemonic [{}/{}]", style(idx).cyan(), style(count).cyan().bold()))
-            .clear(true)
-            .interact_on(&term.term)
+        let word : String = Input::new().with_prompt(&format!("mnemonic [{}/{}]", style(idx).cyan(), style(count).cyan().bold()))
+            .interact()
             .unwrap();
 
         match dic.lookup_mnemonic(&word) {
             Ok(_) => return word,
             Err(bip39::dictionary::Error::MnemonicWordNotFoundInDictionary(_)) => {
                 let prompt = format!("`{}' is not a valid mnemonic word in `{}'", style(word).italic().red(), style(dic.name()).bold().white());
-                while ! Confirmation::new(&prompt).clear(true).default(true).show_default(true).interact_on(&term.term).unwrap() {}
+                while ! Confirmation::new().with_text(&prompt).default(true).show_default(true).interact().unwrap() {}
             }
         }
     }
@@ -91,7 +90,7 @@ pub fn interactive_input_words<D>(term: &mut Term, dic: &D, size: bip39::Type) -
         match validate_mnemonics(dic, size, string) {
             Ok(res) => { return res; },
             Err(prompt) => {
-                while ! Confirmation::new(&prompt).clear(true).default(true).show_default(true).interact_on(&term.term).unwrap() {}
+                while ! Confirmation::new().with_text(&prompt).default(true).show_default(true).interact().unwrap() {}
             }
         }
     }
@@ -103,15 +102,14 @@ pub fn input_mnemonic_phrase<D>(term: &mut Term, dic: &D, size: bip39::Type) -> 
     let count = size.mnemonic_count();
 
     loop {
-        let string = Input::new(&format!("Please enter all your {} mnemonics", style(count).bold().red()))
-            .clear(true)
-            .interact_on(&term.term)
+        let string = Input::new().with_prompt(&format!("Please enter all your {} mnemonics", style(count).bold().red()))
+            .interact()
             .unwrap();
 
         match validate_mnemonics(dic, size, string) {
             Ok(res) => { return res; },
             Err(prompt) => {
-                while ! Confirmation::new(&prompt).clear(true).default(true).show_default(true).interact_on(&term.term).unwrap() {}
+                while ! Confirmation::new().with_text(&prompt).default(true).show_default(true).interact().unwrap() {}
             }
         }
     }

--- a/src/utils/term/mod.rs
+++ b/src/utils/term/mod.rs
@@ -73,7 +73,7 @@ impl Term {
     }
 
     pub fn prompt(&mut self, prompt: &str) -> io::Result<String> {
-        dialoguer::Input::new(prompt).interact()
+        dialoguer::Input::new().with_prompt(prompt).interact()
     }
 
     pub fn password(&mut self, prompt: &str) -> io::Result<String> {
@@ -82,14 +82,14 @@ impl Term {
             // TODO: there seems to be an issue with rust crate: console
             //       the password read line is not working or not returning
             //       at all on windows 10 's `cmd` or `PowerShell`
-            let line = dialoguer::Input::new(prompt).default("").interact()?;
+            let line = dialoguer::Input::new().with_prompt(prompt).default("").interact()?;
             self.term.move_cursor_up(1)?;
             self.term.clear_line()?;
             Ok(line)
         }
         #[cfg(not(windows))]
         {
-            dialoguer::PasswordInput::new(prompt).allow_empty_password(true).interact()
+            dialoguer::PasswordInput::new().with_prompt(prompt).allow_empty_password(true).interact()
         }
     }
 
@@ -100,10 +100,10 @@ impl Term {
                 // TODO: there seems to be an issue with rust crate: console
                 //       the password read line is not working or not returning
                 //       at all on windows 10 's `cmd` or `PowerShell`
-                let line = dialoguer::Input::new(prompt).default("").interact()?;
+                let line = dialoguer::Input::new().with_prompt(prompt).default("").interact()?;
                 self.term.move_cursor_up(1)?;
                 self.term.clear_line()?;
-                let line2 = dialoguer::Input::new(confirmation).default("").interact()?;
+                let line2 = dialoguer::Input::new().with_prompt(confirmation).default("").interact()?;
                 self.term.move_cursor_up(1)?;
                 self.term.clear_line()?;
                 if line == line2 {
@@ -114,9 +114,10 @@ impl Term {
         }
         #[cfg(not(windows))]
         {
-            dialoguer::PasswordInput::new(prompt)
+            dialoguer::PasswordInput::new()
+                .with_prompt(prompt)
                 .allow_empty_password(true)
-                .confirm(confirmation, mismatch_err)
+                .with_confirmation(confirmation, mismatch_err)
                 .interact()
         }
     }

--- a/src/wallet/commands.rs
+++ b/src/wallet/commands.rs
@@ -207,9 +207,7 @@ new transactions will be by recovering the wallet with the mnemonic words.",
     // methods that need to put the user through a confirmation dialog.
     // See issue #45
 
-    let confirmation = ::dialoguer::Confirmation::new("Are you sure?")
-        .use_line_input(true)
-        .clear(false)
+    let confirmation = ::dialoguer::Confirmation::new().with_text("Are you sure?")
         .default(false)
         .interact().unwrap();
     if ! confirmation { ::std::process::exit(0); }


### PR DESCRIPTION
I made a PR to the upstream repo and had to rebase it. The commit
we depends on has disapeared and I needed to upgrade the CLI to
compile it again.

There is a regression though in the sense I need to change the theme
setting to erase the line when prompting the mnemonics or when
displaying the mnemoncis words at creating time

fix #75 