### PR TITLE
temporary fix in the daedalus address recovery until we can update cardano-deps

### DIFF
--- a/src/wallet/state/lookup/randomindex.rs
+++ b/src/wallet/state/lookup/randomindex.rs
@@ -52,6 +52,7 @@ impl AddressLookup for RandomIndexLookup {
         match &utxo.credited_address.attributes.derivation_path {
             None => (),
             Some(ref payload) => {
+                if payload.len() < 20 { return Ok(None) }
                 if payload.len() > 90 { return Ok(None) }
             }
         }

--- a/src/wallet/state/lookup/randomindex.rs
+++ b/src/wallet/state/lookup/randomindex.rs
@@ -49,6 +49,14 @@ impl AddressLookup for RandomIndexLookup {
         &mut self,
         utxo: UTxO<ExtendedAddr>,
     ) -> Result<Option<UTxO<Address>>, AddressLookupError> {
+        match &utxo.credited_address.attributes.derivation_path {
+            None => (),
+            Some(ref payload) => {
+                if payload.len() > 90 { return Ok(None) }
+            }
+        }
+
+
         let opt_addressing = self.generator.try_get_addressing(&utxo.credited_address)?;
 
         match opt_addressing {


### PR DESCRIPTION
see #73 for the issue details

there are currently breaking changes in the cardano-deps this will allow daedalus wallet to work as expected.